### PR TITLE
add: changelog for refresh token endpoint

### DIFF
--- a/latest/changelog.mdx
+++ b/latest/changelog.mdx
@@ -3,6 +3,20 @@ title: 'Changelog'
 description: 'Product updates and announcements'
 ---
 
+<Update label="08th June 2026" description="2026.06.08">
+    ## Improvements
+
+    - Added support for OAuth2 connections where the token refresh endpoint differs from the token endpoint.
+
+</Update>
+
+<Update label="21st May 2026" description="2026.05.21">
+    ## Improvements
+
+    - The Issues tab has been reworked to improve readability by adding search, improving the existing filtering and sort features, and enabling pagination.
+
+</Update>
+
 <Update label="17th February 2026" description="2026.02.17">
     ## Features
 


### PR DESCRIPTION
Adding changelogs for the 21/05 Issues tab release and the proposed 08/06 release of refresh token endpoints being added to the Connections OAuth2 tab.