### PR TITLE
Changelog: Build agent can deploy your project

### DIFF
--- a/latest/changelog.mdx
+++ b/latest/changelog.mdx
@@ -3,6 +3,13 @@ title: 'Changelog'
 description: 'Product updates and announcements'
 ---
 
+<Update label="12th August 2026" description="2026.08.12">
+    ## Features
+
+    - The Build agent can now deploy your project for you. When it proposes a deployment, you'll see a confirmation card in the chat — approve it to deploy right away, or decline and keep working. Clear messages are shown if a deploy can't go ahead.
+
+</Update>
+
 <Update label="22nd July 2026" description="2026.07.22">
     ## Features
 


### PR DESCRIPTION
## Summary

- Adds a changelog entry (2026.08.12) for the new Build agent deploy capability: the agent can now propose deploying the project from chat, shown as a confirmation card (Deploy / Not now), with clear messaging if the deploy can't proceed.
- Source PR: versori/versori-ai#840

## Test plan

- [ ] Render `latest/changelog.mdx` and confirm the new entry appears above the 22nd July 2026 block with correct formatting

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017wkrr3NjUewQmCUYGaRzyW)_